### PR TITLE
add hostname validation option during CA validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.class
 *.pyc
 *.pyd
+.idea/
+venv/
 build/
 doc/_build/
 dist/

--- a/pymongo/common.py
+++ b/pymongo/common.py
@@ -310,6 +310,7 @@ VALIDATORS = {
     'ssl_certfile': validate_readable,
     'ssl_cert_reqs': validate_cert_reqs,
     'ssl_ca_certs': validate_readable,
+    'ssl_validate_hostname': validate_boolean,
     'readpreference': validate_read_preference,
     'read_preference': validate_read_preference,
     'readpreferencetags': validate_tag_sets,

--- a/pymongo/mongo_client.py
+++ b/pymongo/mongo_client.py
@@ -228,6 +228,9 @@ class MongoClient(common.BaseObject):
             "certification authority" certificates, which are used to validate
             certificates passed from the other end of the connection.
             Implies ``ssl=True``. Defaults to ``None``.
+          - `ssl_validate_hostname`: (boolean) Whether to validate the hostname
+            when a ``ssl_ca_cert`` is provided to be validated. Defaults to
+            ``True``.
 
         .. seealso:: :meth:`end_request`
 
@@ -310,10 +313,11 @@ class MongoClient(common.BaseObject):
         self.__ssl_certfile = options.get('ssl_certfile', None)
         self.__ssl_cert_reqs = options.get('ssl_cert_reqs', None)
         self.__ssl_ca_certs = options.get('ssl_ca_certs', None)
+        self.__ssl_validate_hostname = options.get('ssl_validate_hostname', True)
 
         ssl_kwarg_keys = [k for k in kwargs.keys()
                           if k.startswith('ssl_') and kwargs[k]]
-        if self.__use_ssl == False and ssl_kwarg_keys:
+        if self.__use_ssl is False and ssl_kwarg_keys:
             raise ConfigurationError("ssl has not been enabled but the "
                                      "following ssl parameters have been set: "
                                      "%s. Please set `ssl=True` or remove."
@@ -429,14 +433,14 @@ class MongoClient(common.BaseObject):
 
         If `collection_name` is None purge an entire database.
         """
-        if not database_name in self.__index_cache:
+        if database_name not in self.__index_cache:
             return
 
         if collection_name is None:
             del self.__index_cache[database_name]
             return
 
-        if not collection_name in self.__index_cache[database_name]:
+        if collection_name not in self.__index_cache[database_name]:
             return
 
         if index_name is None:
@@ -491,7 +495,8 @@ class MongoClient(common.BaseObject):
             ssl_ca_certs=self.__ssl_ca_certs,
             wait_queue_timeout=self.__wait_queue_timeout,
             wait_queue_multiple=self.__wait_queue_multiple,
-            socket_keepalive=self.__socket_keepalive)
+            socket_keepalive=self.__socket_keepalive,
+            ssl_validate_hostname=self.__ssl_validate_hostname)
 
     def __check_auth(self, sock_info):
         """Authenticate using cached database credentials.
@@ -543,6 +548,7 @@ class MongoClient(common.BaseObject):
             return member.host[1]
 
         return None
+
     @property
     def is_primary(self):
         """If this instance is connected to a standalone, a replica set

--- a/pymongo/pool.py
+++ b/pymongo/pool.py
@@ -118,7 +118,7 @@ class Pool:
                  use_greenlets, ssl_keyfile=None, ssl_certfile=None,
                  ssl_cert_reqs=None, ssl_ca_certs=None,
                  wait_queue_timeout=None, wait_queue_multiple=None,
-                 socket_keepalive=False):
+                 socket_keepalive=False, ssl_validate_hostname=True):
         """
         :Parameters:
           - `pair`: a (hostname, port) tuple
@@ -157,6 +157,9 @@ class Pool:
           - `socket_keepalive`: (boolean) Whether to send periodic keep-alive
             packets on connected sockets. Defaults to ``False`` (do not send
             keep-alive packets).
+          - `ssl_validate_hostname`: (boolean) Whether to validate the hostname
+            when a ``ssl_ca_cert`` is provided to be validated. Defaults to
+            ``True``.
         """
         # Only check a socket's health with _closed() every once in a while.
         # Can override for testing: 0 to always check, None to never check.
@@ -181,6 +184,7 @@ class Pool:
         self.ssl_certfile = ssl_certfile
         self.ssl_cert_reqs = ssl_cert_reqs
         self.ssl_ca_certs = ssl_ca_certs
+        self.ssl_validate_hostname = ssl_validate_hostname
 
         if HAS_SSL and use_ssl and not ssl_cert_reqs:
             self.ssl_cert_reqs = ssl.CERT_NONE
@@ -295,7 +299,7 @@ class Pool:
                                        keyfile=self.ssl_keyfile,
                                        ca_certs=self.ssl_ca_certs,
                                        cert_reqs=self.ssl_cert_reqs)
-                if self.ssl_cert_reqs:
+                if self.ssl_cert_reqs and self.ssl_validate_hostname:
                     match_hostname(sock.getpeercert(), hostname)
 
             except ssl.SSLError:


### PR DESCRIPTION
There are circumstances where you still require a CA to validate that your key and cert are valid, but forgo verifying that the hostname matches the CN.

Link to JIRA: https://jira.mongodb.org/browse/PYTHON-834

This patch adds an extra parameter: `ssl_validate_hostname` which defaults to True.

I'm hoping that this will make it into the 2.8 and future branches.

This is already done in TxMongo which uses Twisted's SSL Context Factory to achieve the same thing.
